### PR TITLE
Replacing clojure.spec with clojure.spec.alpha

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,6 @@
   :url "https://github.com/juxt/tick"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies []
+  :dependencies [[org.clojure/spec.alpha "0.1.94"]]
   :profiles {:dev
              {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]]}})

--- a/src/tick/cal.clj
+++ b/src/tick/cal.clj
@@ -2,7 +2,7 @@
 
 (ns tick.cal
   (:require
-   [clojure.spec :as s])
+   [clojure.spec.alpha :as s])
   (:import
    [java.time Clock ZoneId Instant Duration DayOfWeek Month ZonedDateTime LocalDate YearMonth Month]
    [java.time.temporal ChronoUnit]))

--- a/src/tick/core.clj
+++ b/src/tick/core.clj
@@ -2,7 +2,7 @@
 
 (ns tick.core
   (:require
-   [clojure.spec :as s])
+   [clojure.spec.alpha :as s])
   (:import
    [java.time Clock ZoneId Instant Duration DayOfWeek Month ZonedDateTime LocalDate]
    [java.time.temporal ChronoUnit]))

--- a/src/tick/timeline.clj
+++ b/src/tick/timeline.clj
@@ -2,7 +2,7 @@
 
 (ns tick.timeline
   (:require
-   [clojure.spec :as s])
+   [clojure.spec.alpha :as s])
   (:import
    [java.time Duration ZonedDateTime]))
 


### PR DESCRIPTION
Clojure 1.9.0a16 removed the `clojure.spec` namespace, moving it to a separate lib, under the `clojure.spec.alpha` namespace. This PR adds the spec.alpha lib as a dependency, and updates the namespace references.