### PR TITLE
Unnecessarily specific type annotations on `periodic-seq`

### DIFF
--- a/src/tick/timeline.clj
+++ b/src/tick/timeline.clj
@@ -4,11 +4,12 @@
   (:require
    [clojure.spec :as s])
   (:import
-   [java.time Duration ZonedDateTime]))
+   [java.time ZonedDateTime]
+   [java.time.temporal Temporal TemporalAmount]))
 
 (defn periodic-seq
   "Given a start time, create a timeline with times at constant intervals of period length"
-  ([^ZonedDateTime start ^Duration period]
+  ([^Temporal start ^TemporalAmount period]
    (iterate #(.addTo period %) start)))
 
 (s/def :tick/date #(instance? ZonedDateTime %))


### PR DESCRIPTION
Replacing `ZonedDateTime` and `Duration` with their super-interfaces `Temporal` and `TemporalAmount` allows callers to pass other concrete types to `periodic-seq` - e.g. passing a `Period` rather than a `Duration`.

(This probably applies to the `(s/def :tick/date ...)` too?)