### PR TITLE
Add autodoc for easy publishing of API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+gh-pages

--- a/README.adoc
+++ b/README.adoc
@@ -14,6 +14,10 @@ Add to your lein or boot dependencies:
 
 Tick is dependent on Clojure 1.9, since it uses +clojure.spec+.
 
+== Documentation
+
+- https://juxt.github.io/tick[Generated API docs]
+
 == Timelines
 
 Tick adds the concept of immutable *timelines* to java.time. A

--- a/generate_docs
+++ b/generate_docs
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export AUTODOC_CMD="lein with-profile +codox codox"
+
+\curl -sSL https://raw.githubusercontent.com/plexus/autodoc/master/autodoc.sh | bash

--- a/project.clj
+++ b/project.clj
@@ -8,4 +8,12 @@
   :dependencies [[org.clojure/spec.alpha "0.1.94"]]
   :profiles {:dev
              {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]]
-              :jvm-opts ["-Dclojure.spec.compile-asserts=true"]}})
+              :jvm-opts ["-Dclojure.spec.compile-asserts=true"]}
+             :codox {:dependencies [[codox-theme-rdash "0.1.2"]]
+                     :plugins [[lein-codox "0.10.3"]]
+                     :codox {:project {:name "tick"}
+                             :metadata {:doc/format :markdown} ;; docstring format
+                             :themes [:rdash]
+                             :output-path "gh-pages"
+                             :doc-paths ["CHANGELOG.md"
+                                         "doc/intro.md"]}}})


### PR DESCRIPTION
This adds a `./generate_docs` script powered by
[autodoc](https://github.com/plexus/autodoc), which will generate API docs, and
update the origin/gh-pages branch, thus publishing the result at
https://juxt.github.io/tick .

This script is generally safe and fool proof. See the autodoc README for
details.

Closes #12 