### PR TITLE
Respect clock in date time inst conversion

### DIFF
--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -220,11 +220,11 @@
   (instant [ldt] (instant (zoned-date-time ldt)))
   (offset-date-time [ldt] #?(:clj (cljc.java-time.local-date-time/at-offset
                                     ldt
-                                    (-> (cljc.java-time.zone-id/system-default)
+                                    (-> (current-zone)
                                         (cljc.java-time.zone-id/get-rules)
                                         (.getOffset ldt)))
                              :cljs (zoned-date-time ldt)))
-  (zoned-date-time [ldt] (cljc.java-time.local-date-time/at-zone ldt (cljc.java-time.zone-id/system-default)))
+  (zoned-date-time [ldt] (cljc.java-time.local-date-time/at-zone ldt (current-zone)))
 
   #?(:clj Date :cljs js/Date)
   (inst [d] d)
@@ -670,7 +670,7 @@
 
 (extend-protocol IClock
   Instant
-  (clock [i] (cljc.java-time.clock/fixed i (cljc.java-time.zone-id/system-default)))
+  (clock [i] (cljc.java-time.clock/fixed i (current-zone)))
 
   ZonedDateTime
   (clock [zdt] (cljc.java-time.clock/fixed (.toInstant zdt) (cljc.java-time.zoned-date-time/get-zone zdt)))

--- a/test/tick/alpha/api/dates_test.cljc
+++ b/test/tick/alpha/api/dates_test.cljc
@@ -44,7 +44,23 @@
       (testing "(clock) return type"
         (is (instance? Clock (t/clock))))
       (testing "Time shifting the clock back by 2 hours"
-        (is (= "2018-02-14T13:00:00Z" (str (t/instant (t/<< (t/clock) (t/new-duration 2 :hours)))))))))
+        (is (= "2018-02-14T13:00:00Z" (str (t/instant (t/<< (t/clock) (t/new-duration 2 :hours)))))))
+      (testing "with instant"
+        (is (= (t/zone (t/clock (t/instant)))
+               (t/zone "America/New_York"))))))
+
+  (testing "Converting using with-clock"
+    (t/with-clock (t/clock (t/zone "America/New_York"))
+     (testing "inst to zoned-date-time"
+       (is (= (t/zoned-date-time #inst"2019-08-07T16:00")
+              (t/zoned-date-time "2019-08-07T12:00-04:00[America/New_York]"))))
+     (testing "date-time to zoned-date-time"
+       (is (= (t/zoned-date-time (t/date-time "2019-08-07T12:00"))
+              (t/zoned-date-time "2019-08-07T12:00-04:00[America/New_York]"))))
+     (testing "date-time to offset-date-time"
+       (is (= (t/offset-date-time (t/date-time "2019-08-07T12:00"))
+              #?(:clj (t/offset-date-time "2019-08-07T12:00-04:00")
+                 :cljs (t/zoned-date-time "2019-08-07T12:00-04:00[America/New_York]")))))))
 
   (testing "Creating a clock with a zone, and returning that zone"
     (is (= "America/New_York" (str (t/zone (t/clock (t/zone "America/New_York")))))))


### PR DESCRIPTION
Use `(current-zone)` in core instead of calling
`(cljc.java-time.zone-id/system-default)` directly

Previously creating a clock from an instant, and converting an date-time to a zoned- or offset-date-time did not use the current clock.

Issue #49 