### PR TITLE
complement should work for meeting intervals

### DIFF
--- a/src/tick/interval.cljc
+++ b/src/tick/interval.cljc
@@ -663,8 +663,11 @@
 (defn complement [coll]
   (if (empty? coll)
     [(new-interval (t/min-of-type (t/now)) (t/max-of-type (t/now)))]
-    (let [r (map (fn [[x y]] (new-interval (t/end x) (t/beginning y)))
-                 (partition 2 1 coll))]
+    (let [r (->> coll
+                 (partition 2 1)
+                 (keep (fn [[x y]]
+                         (when-not (meets? x y)
+                           (new-interval (t/end x) (t/beginning y))))))]
       (cond-> r
         (not= (t/beginning (first coll)) (t/min-of-type (t/beginning (first coll))))
         (#(concat [(new-interval (t/min-of-type (t/beginning (first coll))) (t/beginning (first coll)))] %))

--- a/test/tick/interval_test.cljc
+++ b/test/tick/interval_test.cljc
@@ -524,25 +524,23 @@
                             (t/date-time "2018-01-01T00:00"))]
           (disj [(bounds "2017")] (bounds (t/date "2017-07-04"))))))
 
-#_(deftest complement-test
-    ;; Not sure why this is failing on the equals check
-    #_(is (=
-            [[(tick.core/min-of-type (t/time "2017-01-01T00:00:00Z"))
-              (t/time "2017-01-01T00:00:00Z")]
-
-             [(t/time "2017-01-04T00:00:00Z")
-              (t/time "2017-01-05T00:00:00Z")]
-
-             [(t/time "2018-01-01T00:00:00Z")
-              (tick.core/max-of-type (t/time "2017-01-01T00:00:00Z"))
-              ]]
-
-            (complement [[(t/time "2017-01-01T00:00:00Z")
-                          (t/time "2017-07-04T00:00:00Z")]
-                         [(t/time "2017-07-05T00:00:00Z")
-                          (t/time "2018-01-01T00:00:00Z")]])))
-
-    (is (= [] (complement (complement [])))))
+(deftest complement-test
+  (testing "complement through max of type"
+    (is (= [(ti/new-interval (t/time "01:00") (t/max-of-type (t/time "00:00")))]
+           (ti/complement [(ti/new-interval (t/time "00:00") (t/time "01:00"))]))))
+  (testing "complement ordered disjoint intervals"
+    (is (= [(ti/new-interval (t/time "00:00") (t/time "01:00"))
+            (ti/new-interval (t/time "02:00") (t/time "03:00"))
+            (ti/new-interval (t/time "04:00") (t/max-of-type (t/time "00:00")))]
+           (ti/complement [(ti/new-interval (t/time "01:00") (t/time "02:00"))
+                        (ti/new-interval (t/time "03:00") (t/time "04:00"))]))))
+  (testing "complement meeting intervals"
+    (is (= [(ti/new-interval (t/time "00:00") (t/time "01:00"))
+            (ti/new-interval (t/time "03:00") (t/max-of-type (t/time "00:00")))]
+           (ti/complement [(ti/new-interval (t/time "01:00") (t/time "02:00"))
+                        (ti/new-interval (t/time "02:00") (t/time "03:00"))]))))
+  (testing "complement empty interval round trip"
+    (is (= [] (ti/complement (ti/complement []))))))
 
 
 ;; Division test


### PR DESCRIPTION
resolves #58 
This is the minimal fix for this issue, and I got some tests working.

I think it may additionally be worth adding a precondition to check that the collection argument satisfies `ordered-disjoint-intervals?` (`group-by-intervals` does this). 

Alternatively, and I'm less confident this is a good idea, `tick.interval/unite` could be called on the collection argument prior to handling it, so that overlapping intervals in a collection could also be valid.