### PR TITLE
Kt day constructor fixes

### DIFF
--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -82,29 +82,29 @@
 
 (defn parse-day [input]
   (condp re-matches (str/lower-case input)
-    #"(mon)(day)?" cljc.java-time.day-of-week/monday
-    #"(tue)(s|sday)?" cljc.java-time.day-of-week/tuesday
-    #"(wed)(s|nesday)?" cljc.java-time.day-of-week/wednesday
-    #"(thur)(s|sday)?" cljc.java-time.day-of-week/thursday
-    #"(fri)(day)?" cljc.java-time.day-of-week/friday
-    #"(sat)(urday)?" cljc.java-time.day-of-week/saturday
-    #"(sun)(day)?" cljc.java-time.day-of-week/sunday
+    #"^(mon)(day)?$" cljc.java-time.day-of-week/monday
+    #"^(tue)(s|sday)?$" cljc.java-time.day-of-week/tuesday
+    #"^(wed)(s|nesday)?$" cljc.java-time.day-of-week/wednesday
+    #"^(thur)(s|sday)?$" cljc.java-time.day-of-week/thursday
+    #"^(fri)(day)?$" cljc.java-time.day-of-week/friday
+    #"^(sat)(urday)?$" cljc.java-time.day-of-week/saturday
+    #"^(sun)(day)?$" cljc.java-time.day-of-week/sunday
     nil))
 
 (defn parse-month [input]
   (condp re-matches (str/lower-case input)
-    #"(jan)(uary)?" cljc.java-time.month/january
-    #"(feb)(ruary)?" cljc.java-time.month/february
-    #"(mar)(ch)?" cljc.java-time.month/march
-    #"(apr)(il)?" cljc.java-time.month/april
-    #"may" cljc.java-time.month/may
-    #"(jun)(e)?" cljc.java-time.month/june
-    #"(jul)(y)?" cljc.java-time.month/july
-    #"(aug)(ust)?" cljc.java-time.month/august
-    #"(sep)(tember)?" cljc.java-time.month/september
-    #"(oct)(ober)?" cljc.java-time.month/october
-    #"(nov)(ember)?" cljc.java-time.month/november
-    #"(dec)(ember)?" cljc.java-time.month/december
+    #"^(jan)(uary)?$" cljc.java-time.month/january
+    #"^(feb)(ruary)?$" cljc.java-time.month/february
+    #"^(mar)(ch)?$" cljc.java-time.month/march
+    #"^(apr)(il)?$" cljc.java-time.month/april
+    #"^may$" cljc.java-time.month/may
+    #"^(jun)(e)?$" cljc.java-time.month/june
+    #"^(jul)(y)?$" cljc.java-time.month/july
+    #"^(aug)(ust)?$" cljc.java-time.month/august
+    #"^(sep)(tember)?$" cljc.java-time.month/september
+    #"^(oct)(ober)?$" cljc.java-time.month/october
+    #"^(nov)(ember)?$" cljc.java-time.month/november
+    #"^(dec)(ember)?$" cljc.java-time.month/december
     nil))
 
 (defprotocol IParseable

--- a/test/tick/alpha/api_test.cljc
+++ b/test/tick/alpha/api_test.cljc
@@ -9,6 +9,8 @@
     [tick.format :as t.f]
     [cljc.java-time.clock]
     [cljc.java-time.instant]
+    [cljc.java-time.day-of-week]
+    [cljc.java-time.month]
     [cljs.java-time.interop :as t.i]
     #?(:clj
        [tick.deprecated.cal :as cal])
@@ -188,6 +190,31 @@
     (is (= (t/new-interval (t/date-time "2017-08-08T12:00:00")
              (t/date-time "2017-08-09T00:00:00"))
           (t/pm (t/today))))))
+
+(deftest day-of-week
+  (let [days (fn [strings] (map t/day-of-week strings))]
+    (is (every? #{cljc.java-time.day-of-week/sunday} (days ["sun" "sunday"])))
+    (is (every? #{cljc.java-time.day-of-week/monday} (days ["mon" "monday"])))
+    (is (every? #{cljc.java-time.day-of-week/tuesday} (days ["tue" "tues" "tuesday"])))
+    (is (every? #{cljc.java-time.day-of-week/wednesday} (days ["wed" "weds" "wednesday"])))
+    (is (every? #{cljc.java-time.day-of-week/thursday} (days ["thur" "thurs" "thursday"])))
+    (is (every? #{cljc.java-time.day-of-week/friday} (days ["fri" "friday"])))
+    (is (every? #{cljc.java-time.day-of-week/saturday} (days ["sat" "saturday"])))))
+
+(deftest month
+  (let [months (fn [strings] (map t/month strings))]
+    (is (every? #{cljc.java-time.month/january} (months ["jan" "january"])))
+    (is (every? #{cljc.java-time.month/february} (months ["feb" "february"])))
+    (is (every? #{cljc.java-time.month/march} (months ["mar" "march"])))
+    (is (every? #{cljc.java-time.month/april} (months ["apr" "april"])))
+    (is (every? #{cljc.java-time.month/may} (months ["may"])))
+    (is (every? #{cljc.java-time.month/june} (months ["jun" "june"])))
+    (is (every? #{cljc.java-time.month/july} (months ["jul" "july"])))
+    (is (every? #{cljc.java-time.month/august} (months ["aug" "august"])))
+    (is (every? #{cljc.java-time.month/september} (months ["sep" "september"])))
+    (is (every? #{cljc.java-time.month/october} (months ["oct" "october"])))
+    (is (every? #{cljc.java-time.month/november} (months ["nov" "november"])))
+    (is (every? #{cljc.java-time.month/december} (months ["dec" "december"])))))
 
 ;; Durations. Simple constructors to create durations of specific
 ;; units.

--- a/test/tick/alpha/api_test.cljc
+++ b/test/tick/alpha/api_test.cljc
@@ -169,8 +169,9 @@
           (t/now)
           (t/+ (t/now) (t/new-duration 20 :seconds))
           (t/+ (t/now) (t/new-duration 10 :seconds)))))
-  (is (t/<= (t/now) (t/now) (t/+ (t/now) (t/new-duration 1 :seconds))))
-  (is (t/>= (t/now) (t/now) (t/- (t/now) (t/new-duration 10 :seconds))))
+  (let [at (t/now)]
+    (is (t/<= at at (t/+ at (t/new-duration 1 :seconds))))
+    (is (t/>= at at (t/- at (t/new-duration 10 :seconds)))))
 
   (testing "durations"
     (is (t/> (t/new-duration 20 :seconds) (t/new-duration 10 :seconds)))


### PR DESCRIPTION
Due to subtle differences in regex API in the JVM vs JS runtime, some constructors were broken.

In Clojurescript
```cljs
(re-matches #"(tue)(s|sday)?" "tuesday")
=> nil
(re-matches #"^(tue)(s|sday)?$" "tuesday")
=> ["tuesday" "tue" "sday"]
```
Wheras in Clojure
```clj
(re-matches #"(tue)(s|sday)?" "tuesday")
=> ["tuesday" "tue" "sday"]
(re-matches #"^(tue)(s|sday)?$" "tuesday")
=> ["tuesday" "tue" "sday"]
```

This means we can't use `(t/day-of-week "TUESDAY")` in Clojurescript. The additional prefix/suffix isn't necessary for all the days/months but I thought it better to be consistent.

Also thanks a lot for putting this library together and open-sourcing it. It's very well written and easy to read. I'm getting a ton of mileage out of it!