### PR TITLE
Implement ITimeComparison and IBetween for #inst

### DIFF
--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -978,7 +978,9 @@
             Temporal
             (between [v1 v2] (Duration/between v1 v2))])
   #?(:clj String :cljs string)
-  (between [v1 v2] (between (parse v1) (parse v2))))
+  (between [v1 v2] (between (parse v1) (parse v2)))
+  #?(:clj Date :cljs js/Date)
+  (between [x y] (between (instant x) (instant y))))
 
 ;; TODO: Test concurrent? in tick.core-test
 

--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -536,8 +536,11 @@
   (<= [x y] (not (.isAfter x y)))
   (> [x y] (.isAfter x y))
   (>= [x y] (not (.isBefore x y)))
-  ;Date
-  ;(-compare [x y] (.compareTo x y))
+  #?(:clj Date :cljs js/Date)
+  (<  [x y] (neg? (compare x y)))
+  (<= [x y] (not (pos? (compare x y))))
+  (>  [x y] (pos? (compare x y)))
+  (>= [x y] (not (neg? (compare x y))))
   LocalDate
   (< [x y] (.isBefore x y))
   (<= [x y] (not (.isAfter x y)))

--- a/test/tick/alpha/api_test.cljc
+++ b/test/tick/alpha/api_test.cljc
@@ -182,6 +182,26 @@
     (is (t/<= (t/new-duration 20 :seconds) (t/new-duration 20 :seconds)))))
 
 
+(deftest comparison-test-date
+  (let [t1 #inst "2019-12-24"
+        t2 #inst "2019-12-31"]
+
+    (is (t/< t1 t2))
+    (is (not (t/< t1 t1)))
+    (is (not (t/< t2 t1)))
+
+    (is (t/<= t1 t2))
+    (is (t/<= t1 t1))
+    (is (not (t/<= t2 t1)))
+
+    (is (not (t/> t1 t2)))
+    (is (not (t/> t1 t1)))
+    (is (t/> t2 t1))
+
+    (is (not (t/>= t1 t2)))
+    (is (t/>= t1 t1))
+    (is (t/>= t2 t1))))
+
 (deftest am-test
   (t/with-clock (cljc.java-time.clock/fixed (t/instant "2017-08-08T12:00:00Z") t/UTC)
     (is (= (t/new-interval (t/date-time "2017-08-08T00:00:00")

--- a/test/tick/alpha/api_test.cljc
+++ b/test/tick/alpha/api_test.cljc
@@ -132,6 +132,11 @@
       (t/new-duration 2 :minutes)
       (t/between "2020-01-01T12:00" "2020-01-01T12:02")))
 
+  (is
+   (=
+    (t/new-duration 2 :minutes)
+    (t/between #inst "2020-01-01T12:00" #inst "2020-01-01T12:02")))
+
   (testing "LocalDate"
     (is (= (t/new-period 1 :days)
           (t/between (t/date "2020-01-01")


### PR DESCRIPTION
Pull request implements `ITimeComparison` as discussed in #74  and adds implementation for IBetween.