### PR TITLE
Doesn't remove ys head in case :during

### DIFF
--- a/src/tick/interval.cljc
+++ b/src/tick/interval.cljc
@@ -616,7 +616,7 @@
                        (:finishes :during :equals)
                        (difference
                          (assert-proper-head (next xs))
-                         (assert-proper-head (next ys)))
+                         (assert-proper-head ys))
 
                        :starts
                        (difference


### PR DESCRIPTION
:during case for instance/difference was ignoring end of Y
Fixes #76 