### PR TITLE
Fix bug in parse function

### DIFF
--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -126,7 +126,7 @@
       :>> (fn [s] (cljc.java-time.local-time/parse s))
       #"(\d{1,2}):(\d{2})"
       :>> (fn [[_ h m]] (cljc.java-time.local-time/of (parse-int h) (parse-int m)))
-      #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z"
+      #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z(?!\[\w+\/\w+\])"
       :>> (fn [s] (cljc.java-time.instant/parse s))
       #"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?[+-]\d{2}:\d{2}"
       :>> (fn [s] #?(:clj (cljc.java-time.offset-date-time/parse s)


### PR DESCRIPTION
Fix bug where zoned-date-time strings are mistakenly identified as instants, causing the parse function to throw.

Specifically, the string "2020-03-06T01:02:04.637Z[Europe/London]" is identified as an instant when in fact it is not a valid instant, but a valid zoned-date-time. Instants cannot have a time zone so I have updated the regex to reflect this.

To reproduce the bug:

`(t/parse (str (t/zoned-date-time #inst "2019")))`
Should return `#time/zoned-date-time "2019-01-01T00:00Z[Europe/London]"`
Instead it returns
 ```
Execution error (DateTimeParseException) at java.time.format.DateTimeFormatter/parseResolved0 (DateTimeFormatter.java:2049).
Text '2019-01-01T00:00Z[Europe/London]' could not be parsed, unparsed text found at index 16
```
