### PR TITLE
Use Period for step increment for LocalDate (range) calls.

### DIFF
--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -862,7 +862,7 @@
     ([from] (iterate #(.plusDays % 1) from))
     ([from to] (cond->> (iterate #(.plusDays % 1) from)
                  to (take-while #(< % to))))
-    ([from to step] (cond->> (iterate #(.plusDays % step) from)
+    ([from to step] (cond->> (iterate #(.plus % step) from)
                       to (take-while #(< % to))))))
 
 (defn inc [t] (forward-number t 1))

--- a/src/tick/deprecated/cal.clj
+++ b/src/tick/deprecated/cal.clj
@@ -32,7 +32,7 @@
   (first (drop-while #(not= (day-of-week %) day) (t/range ld))))
 
 (defn- last-named-day-from [ld day]
-  (first (drop-while #(not= (day-of-week %) day) (t/range ld nil -1))))
+  (first (drop-while #(not= (day-of-week %) day) (t/range ld nil (t/new-period -1 :days)))))
 
 (defn first-monday-of-month [^YearMonth ym]
   (first-named-day-from (.atDay ym 1) DayOfWeek/MONDAY))


### PR DESCRIPTION
TemporalAmount as the step param instead of using a Long and only
being incrementable by days. This matches the behavior of the other
functions.

In response to my own discovery of Issue #84 which was submitted by someone else.

https://github.com/juxt/tick/issues/84