### PR TITLE
+/- functions on the api work on durations only.

### DIFF
--- a/src/tick/alpha/api.cljc
+++ b/src/tick/alpha/api.cljc
@@ -180,13 +180,13 @@
 ;; Arithmetic
 
 (defn +
-  ([] (. Duration -ZERO))
+  ([] cljc.java-time.duration/zero)
   ([arg] arg)
   ([arg & args]
    (reduce #(core/+ %1 %2) arg args)))
 
 (defn -
-  ([] (. Duration -ZERO))
+  ([] cljc.java-time.duration/zero)
   ([arg] (core/negated arg))
   ([arg & args]
    (reduce #(core/- %1 %2) arg args)))

--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -754,22 +754,18 @@
 ;; Arithmetic
 
 (defprotocol ITimeArithmetic
-  (+ [t d] "Add to time")
-  (- [t d] "Subtract from time, or negate"))
-
-(defn minus_
-  ([d] (.negated d))
-  ([t d] (.minus t d)))
+  (+ [t d] "Add durations")
+  (- [t d] "Subtract from duration, or negate"))
 
 (extend-protocol ITimeArithmetic
-  #?(:clj Object :cljs object)
-  (+ [t d] (.plus t d))
-  (- [t d] (.minus t d)))
+  Duration
+  (+ [t d] (cljc.java-time.duration/plus t d))
+  (- [t d] (cljc.java-time.duration/minus t d)))
 
 (defn negated
   "Return the duration as a negative duration"
   [d]
-  (.negated d))
+  (cljc.java-time.duration/negated d))
 
 (defprotocol ITimeShift
   (forward-number [_ n] "Increment time")

--- a/test/tick/alpha/api_test.cljc
+++ b/test/tick/alpha/api_test.cljc
@@ -121,8 +121,8 @@
     (=
       (let [now (t/now)]
         (t/between
-          (t/- now (t/new-duration 10 :seconds))
-          (t/+ now (t/new-duration 10 :seconds))))
+          (t/<< now (t/new-duration 10 :seconds))
+          (t/>> now (t/new-duration 10 :seconds))))
       (t/new-duration 20 :seconds)))
   (is
     (= (t/new-duration 48 :hours)
@@ -164,21 +164,21 @@
   (is
     (t/<
       (t/now)
-      (t/+ (t/now) (t/new-duration 10 :seconds))
-      (t/+ (t/now) (t/new-duration 20 :seconds))))
+      (t/>> (t/now) (t/new-duration 10 :seconds))
+      (t/>> (t/now) (t/new-duration 20 :seconds))))
   (is
     (t/>
-      (t/+ (t/now) (t/new-duration 20 :seconds))
-      (t/+ (t/now) (t/new-duration 10 :seconds))
+      (t/>> (t/now) (t/new-duration 20 :seconds))
+      (t/>> (t/now) (t/new-duration 10 :seconds))
       (t/now)))
   (is (not
         (t/<
           (t/now)
-          (t/+ (t/now) (t/new-duration 20 :seconds))
-          (t/+ (t/now) (t/new-duration 10 :seconds)))))
+          (t/>> (t/now) (t/new-duration 20 :seconds))
+          (t/<< (t/now) (t/new-duration 10 :seconds)))))
   (let [at (t/now)]
-    (is (t/<= at at (t/+ at (t/new-duration 1 :seconds))))
-    (is (t/>= at at (t/- at (t/new-duration 10 :seconds)))))
+    (is (t/<= at at (t/>> at (t/new-duration 1 :seconds))))
+    (is (t/>= at at (t/<< at (t/new-duration 10 :seconds)))))
 
   (testing "durations"
     (is (t/> (t/new-duration 20 :seconds) (t/new-duration 10 :seconds)))
@@ -463,7 +463,7 @@
 (defn moment [t]
   (t/new-interval
     t
-    (t/+ t (t/new-duration 3 :seconds))))
+    (t/>> t (t/new-duration 3 :seconds))))
 
 ;; TODO: Think about conversions between single instants and intervals. Feather? Widen? Smudge?
 


### PR DESCRIPTION
The +/- and >>/<< functions overlap in that they can be used to shift date/time entities  - as shown for example in https://juxt.land/tick/docs/index.html#_simple_maths 

 +/- are making an analogy to maths operations, but the analogy only holds up when the arguments are all durations (commutativity etc). 

These examples show the analogy working well:

(t/+) => 0
(t/+ a) => a
(t/+ a b c) => sum of a,b and c durations

but when used to move a date by some hours etc, the analogy doesn't hold up, and there is already >>/<< which will work for that.

If we go ahead with this, the docs will also need updating