### PR TITLE
Add new-year-month to core, api

### DIFF
--- a/src/tick/alpha/api.cljc
+++ b/src/tick/alpha/api.cljc
@@ -42,6 +42,7 @@
 
 (def new-time core/new-time)
 (def new-date core/new-date)
+(def new-year-month core/new-year-month)
 
 ;; Surfacing some useful constants
 

--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -185,6 +185,12 @@
   ([epoch-day]
    (cljc.java-time.local-date/of-epoch-day epoch-day)))
 
+
+(defn new-year-month
+  ([] (cljc.java-time.year-month/now))
+  ([year month]
+   (cljc.java-time.year-month/of year month)))
+
 (defn current-zone
   "Return the current zone, which can be overridden by the *clock* dynamic var"
   []
@@ -1146,3 +1152,4 @@
 (defn zone-offset?      [v] (cljc.java-time.extn.predicates/zone-offset? v))
 (defn zoned-date-time?  [v] (cljc.java-time.extn.predicates/zoned-date-time? v))
 (defn interval?         [v] (satisfies? ITimeSpan v))
+

--- a/test/tick/alpha/api_test.cljc
+++ b/test/tick/alpha/api_test.cljc
@@ -33,12 +33,14 @@
   (is (= Month (type (t/month 12))))
   (is (= t/DECEMBER (t/month 12)))
   (is (= (t/new-date 3030 3 3)
-        (t/date "3030-03-03")))
+         (t/date "3030-03-03")))
   (is (-> (t/new-duration 1000 :millis)
           (t/inst)
           (t/instant)
           (cljc.java-time.instant/to-epoch-milli)
-          (= 1000))))
+          (= 1000)))
+  (is (= (t/new-year-month 2020 7)
+         (t/year-month  "2020-07"))))
 
 (deftest extraction-test
   (is (= 2 (t/int t/FEBRUARY)))


### PR DESCRIPTION
I added a test for the constructor. I don't know if that is sufficient. I'm happy to make the necessary changes. 