### PR TITLE
Various type hints for GraalVM native image

### DIFF
--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -614,7 +614,7 @@
 
 (defn truncate [x u]
   (when-let [u (get unit-map u)]
-    (.truncatedTo x u)))
+    (.truncatedTo ^Instant x u)))
 
 ;; Durations & Periods
 


### PR DESCRIPTION
Hi there,

I have been using Tick in my project for some time, but when I recently migrated from a JavaScript/NodeJS runtime to a Java/GraalVM runtime, I found that various type hints were needed in order for the GraalVM `native-image` command to build working executables.

Thanks 🙂