### PR TITLE
Use Kaocha to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,43 +3,79 @@
 # Check https://circleci.com/docs/2.0/language-clojure/ for more details
 #
 version: 2
-jobs:
-  build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/clojure:tools-deps-1.9.0.394-node-browsers
 
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
+references:
+  base_docker: &base_docker
     working_directory: ~/repo
+    docker:
+      - image: circleci/clojure:openjdk-11-tools-deps-node-browsers
 
     environment:
       # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
 
+jobs:
+  test_clj:
+    <<: *base_docker
     steps:
       - checkout
-
       # Download and cache dependencies
       - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "deps.edn" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      # need a few bits for cljs test - there must be a better way of including?
-      - run: sudo npm install karma-cli -g
-      - run: npm install karma --save-dev 
-      - run: npm install karma-chrome-launcher  
-      - run: npm install karma-cljs-test
-          
-      - run: sudo apt-get install -y make        
-      - run: make test
+          key: v1-dependencies-{{ checksum "deps.edn" }}
 
       - save_cache:
           paths:
             - ~/.m2
+
           key: v1-dependencies-{{ checksum "deps.edn" }}
+
+      - run: ./bin/kaocha :clj --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
+
+      - store_test_results:
+          path: test-results
+
+  test_cljs_node:
+    <<: *base_docker
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-dependencies-{{ checksum "deps.edn" }}
+
+      - run: sudo npm install karma-cli -g
+      - run: npm install karma --save-dev
+      - run: npm install karma-chrome-launcher
+      - run: npm install karma-cljs-test
+
+      - run: sudo apt-get install -y make
+      - run: make test-node
+
+      - store_test_results:
+          path: test-results
+
+  test_cljs_browser:
+    <<: *base_docker
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "deps.edn" }}
+
+      - run: sudo npm install karma-cli -g
+      - run: npm install karma --save-dev
+      - run: npm install karma-chrome-launcher
+      - run: npm install karma-cljs-test
+
+      - run: sudo apt-get install -y make
+      - run: make test-chrome
+
+      - store_test_results:
+          path: test-results
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - test_clj
+      - test_cljs_node
+      - test_cljs_browser

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((nil . ((cider-clojure-cli-global-options . "-A:dev:test-clj"))))

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ gh-pages
 /doc/index.html
 .cpcache/
 /DELETE_ME
-/.dir-locals.el
 /.shadow-cljs/
 /doc/js/
 /todo.org
@@ -22,3 +21,5 @@ node_modules/
 /docs/index.html
 /docs/js
 /cljs-test-runner-out
+/.cljs_node_repl/
+/out/

--- a/Makefile
+++ b/Makefile
@@ -19,24 +19,24 @@ docs/index.html:	docs/*.adoc docs/docinfo*.html ${STYLESDIR}/${STYLESHEET}
 			docs/index.adoc
 
 test-clj:
-			clojure -Atest -e deprecated
+			./bin/kaocha :clj
 test-chrome:
-			rm -rf cljs-test-runner-out && mkdir -p cljs-test-runner-out/gen && clojure -Sverbose -Atest-chrome
+			rm -rf cljs-test-runner-out && mkdir -p cljs-test-runner-out/gen && clojure -Sverbose -M:test-chrome
+
 test-node:
-			rm -rf cljs-test-runner-out && mkdir -p cljs-test-runner-out/gen && clojure -Sverbose -Atest-node
-test:
+			rm -rf cljs-test-runner-out && mkdir -p cljs-test-runner-out/gen && clojure -Sverbose -M:test-node
+
+test-all:
 			make test-clj && make test-chrome && make test-node
 
 # For developing the cljs used by the documentation, add --repl and change docs.cljs.edn optimizations to :none to develop interactively
 dev-docs-cljs:
-			clojure -Adocs-index
+			clojure -A:docs-index
 
 install:
-			clj -Arelease install
-deploy:			
-			clj -A:release
-nrepl:
-			clj -Adev:dev-nrepl -m nrepl.cmdline --middleware "[cider.piggieback/wrap-cljs-repl]" --port 5610
+			clojure -A:release install
+deploy:
+			clojure -A:release
 
 # hooray for stackoverflow
 .PHONY: list

--- a/README.adoc
+++ b/README.adoc
@@ -27,12 +27,12 @@ minor changes.
 
 == Install
 
-Get the latest from https://clojars.org/tick[Clojars] and 
-add to your `project.clj`, `build.boot` or `deps.edn`. 
+Get the latest from https://clojars.org/tick[Clojars] and
+add to your `project.clj`, `build.boot` or `deps.edn`.
 
 Tick versions 0.4.24-alpha and up require minimum Clojurescript version of 1.10.741
 
-There are some extra considerations when using tick from Clojurescript, see file `docs/cljs.adoc` in this repo. 
+There are some extra considerations when using tick from Clojurescript, see file `docs/cljs.adoc` in this repo.
 
 Here is a one-liner to drop into a node repl with tick:
 
@@ -74,10 +74,10 @@ Once in, start cljs build with:
 (figwheel-start!)
 ----
 
-Run tests with:
+Run all tests with:
 
 ----
-make test
+make test-all
 ----
 
 === npm dependencies
@@ -91,7 +91,7 @@ npm install karma-chrome-launcher
 npm install karma-cljs-test
 ----
 
-=== Release 
+=== Release
 
 create a git tag
 
@@ -100,9 +100,6 @@ create a git tag
 `make release`  - you need to have set up clojars creds as per https://github.com/applied-science/deps-library
 
 `git push origin new-tag-name`
-
-
-
 
 == Documentation
 

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+clojure -M:test-clj -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -6,57 +6,49 @@
   time-literals/time-literals   {:mvn/version "0.1.5" :exclusions [cljs.java-time/cljs.java-time]}}
 
  :aliases
-        {:release
-                      {:extra-deps {applied-science/deps-library {:mvn/version "RELEASE"}}
-                       :main-opts  ["-m" "applied-science.deps-library"]}
-         :dev
-                      {:extra-deps
-                                    {com.bhauman/figwheel-main          {:mvn/version "0.1.9"}
-                                     com.bhauman/cljs-test-display      {:mvn/version "0.1.1"}
-                                     org.clojure/clojurescript          {:mvn/version "1.10.764"}
-                                     org.clojure/data.xml               {:mvn/version "0.2.0-alpha5"}
-                                     org.clojure/tools.namespace        {:mvn/version "0.2.11"}
-                                     org.apache.xmlgraphics/batik-swing {:mvn/version "1.9"}
-                                     io.aviso/pretty                    {:mvn/version "0.1.34"}
-                                     spyscope/spyscope                  {:mvn/version "0.1.6"}
-                                     fipp/fipp                          {:mvn/version "0.6.12"}}
+ {:release
+  {:extra-deps {applied-science/deps-library {:mvn/version "RELEASE"}}
+   :main-opts  ["-m" "applied-science.deps-library"]}
+  :dev
+  {:extra-deps
+   {com.bhauman/figwheel-main          {:mvn/version "0.2.12"}
+    cider/piggieback                   {:mvn/version "0.4.0"}
+    com.bhauman/cljs-test-display      {:mvn/version "0.1.1"}
+    org.clojure/clojurescript          {:mvn/version "1.10.764"}
+    org.clojure/data.xml               {:mvn/version "0.2.0-alpha5"}
+    org.clojure/tools.namespace        {:mvn/version "0.2.11"}
+    org.apache.xmlgraphics/batik-swing {:mvn/version "1.9"}
+    io.aviso/pretty                    {:mvn/version "0.1.34"}
+    spyscope/spyscope                  {:mvn/version "0.1.6"}
+    fipp/fipp                          {:mvn/version "0.6.12"}}
 
-                       :extra-paths ["dev/src" "test"]
-                       :jvm-opts    ["-Dclojure.spec.compile-asserts=true"]}
-         :test-chrome {:extra-paths ["test" "cljs-test-runner-out/gen"]
-                       :extra-deps  {olical/cljs-test-runner   {:mvn/version "3.7.0" :exclusions [org.clojure/clojurescript]}
-                                     org.clojure/clojurescript {:mvn/version "1.10.764"}}
-                       :main-opts   ["-m" "cljs-test-runner.main" "-c" "test/cljs-test-opts.edn -x chrome-headless"]}
-         ; this is node using foreign-libs.
-         ; although not recommended, whilst tick depends on cljsjs, this should 'just work'
-         :test-node   {:extra-paths ["test" "cljs-test-runner-out/gen"]
-                       :extra-deps  {olical/cljs-test-runner   {:mvn/version "3.7.0" :exclusions [org.clojure/clojurescript]}
-                                     org.clojure/clojurescript {:mvn/version "1.10.764"}}
-                       :main-opts   ["-m" "cljs-test-runner.main" "-x node"]}
-         :docs-index  {:jvm-opts    ["-Xmx500M"]
-                       :extra-paths ["docs/src"]
-                       :extra-deps  {reagent/reagent           {:mvn/version "0.8.1"}
-                                     com.bhauman/figwheel-main {:mvn/version "0.2.6"}
-                                     org.clojure/clojurescript {:mvn/version "1.10.764"}}
-                       :main-opts   ["-m" "figwheel.main" "--build" "docs"]
-                       }
-         :test        {:extra-paths ["test"]
-                       :extra-deps  {
-                                     com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                                :sha     "028a6d41ac9ac5d5c405dfc38e4da6b4cc1255d5"}}
-                       :main-opts   ["-m" "cognitect.test-runner"]}
-         :dev-nrepl   {:extra-deps {nrepl/nrepl      {:mvn/version "0.6.0"}
-                                    cider/piggieback {:mvn/version "0.4.0"}}}
-         :emacs-nrepl {:jvm-opts    ["-Dnrepl.load=true"]
-                       :extra-paths ["aliases/nrepl"]
-                       :extra-deps
-                                    {cider/cider-nrepl       {:mvn/version "0.17.0"}
-                                     ;;refactor-nrepl {:mvn/version "2.3.1"}
-                                     com.cemerick/piggieback {:mvn/version "0.2.2"}
-                                     org.clojure/tools.nrepl {:mvn/version "0.2.12"}}}
+   :extra-paths ["dev/src" "test"]
+   :jvm-opts    ["-Dclojure.spec.compile-asserts=true"]}
 
-         :dev-rebel   {:extra-paths ["aliases/rebel"]
-                       :extra-deps  {com.bhauman/rebel-readline      {:mvn/version "0.1.1"}
-                                     com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
-                                     io.aviso/pretty                 {:mvn/version "0.1.34"}}
-                       :main-opts   ["-m" "tick.rebel.main"]}}}
+  :test-clj {:extra-deps {lambdaisland/kaocha           {:mvn/version "1.0.732"}
+                          lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}}
+
+             :extra-paths ["test"]}
+  :test-chrome {:extra-paths ["test" "cljs-test-runner-out/gen"]
+                :extra-deps  {olical/cljs-test-runner   {:mvn/version "3.7.0" :exclusions [org.clojure/clojurescript]}
+                              org.clojure/clojurescript {:mvn/version "1.10.764"}}
+                :main-opts   ["-m" "cljs-test-runner.main" "-c" "test/cljs-test-opts.edn -x chrome-headless"]}
+                                        ; this is node using foreign-libs.
+                                        ; although not recommended, whilst tick depends on cljsjs, this should 'just work'
+  :test-node   {:extra-paths ["test" "cljs-test-runner-out/gen"]
+                :extra-deps  {olical/cljs-test-runner   {:mvn/version "3.7.0" :exclusions [org.clojure/clojurescript]}
+                              org.clojure/clojurescript {:mvn/version "1.10.764"}}
+                :main-opts   ["-m" "cljs-test-runner.main" "-x node"]}
+
+  :docs-index {:jvm-opts    ["-Xmx500M"]
+               :extra-paths ["docs/src"]
+               :extra-deps  {reagent/reagent           {:mvn/version "0.8.1"}
+                             com.bhauman/figwheel-main {:mvn/version "0.2.12"}
+                             org.clojure/clojurescript {:mvn/version "1.10.764"}}
+               :main-opts   ["-m" "figwheel.main" "--build" "docs"]}
+
+  :dev-rebel {:extra-paths ["aliases/rebel"]
+              :extra-deps  {com.bhauman/rebel-readline      {:mvn/version "0.1.1"}
+                            com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
+                            io.aviso/pretty                 {:mvn/version "0.1.34"}}
+              :main-opts   ["-m" "tick.rebel.main"]}}}

--- a/test/tick/alpha/api_test.cljc
+++ b/test/tick/alpha/api_test.cljc
@@ -7,6 +7,7 @@
        :cljs [cljs.test :refer-macros [deftest is testing run-tests]])
     [tick.alpha.api :as t]
     [tick.format :as t.f]
+    [tick.locale-en-us]
     [cljc.java-time.clock]
     [cljc.java-time.instant]
     [cljc.java-time.day-of-week]

--- a/test/tick/interval_test.cljc
+++ b/test/tick/interval_test.cljc
@@ -244,17 +244,16 @@
         [(ti/new-interval (t/date "2017-06-15") (t/date "2017-06-25"))
          (ti/new-interval (t/date "2017-06-26") (t/date "2017-06-28"))
          (ti/new-interval (t/date "2017-06-30") (t/date "2017-07-04"))]]
-    (=
-      [{:tick/intervals
-        [{:tick/beginning (t/date-time "2017-06-15T00:00")
-          :tick/end (t/date-time "2017-06-26T00:00")}
-         {:tick/beginning (t/date-time "2017-06-26T00:00")
-          :tick/end (t/date-time "2017-06-29T00:00")}]}
-       {:tick/intervals
-        [{:tick/beginning (t/date-time "2017-06-30T00:00")
-          :tick/end (t/date-time "2017-07-05T00:00")}]}]
+    (is (= [{:tick/intervals
+             [{:tick/beginning (t/date-time "2017-06-15T00:00")
+               :tick/end (t/date-time "2017-06-26T00:00")}
+              {:tick/beginning (t/date-time "2017-06-26T00:00")
+               :tick/end (t/date-time "2017-06-29T00:00")}]}
+            {:tick/intervals
+             [{:tick/beginning (t/date-time "2017-06-30T00:00")
+               :tick/end (t/date-time "2017-07-05T00:00")}]}]
 
-      (ti/normalize intervals))))
+           (ti/normalize intervals)))))
 
 (deftest union-test
   (testing "counts"

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,10 @@
+#kaocha/v1
+{:plugins [:kaocha.plugin.alpha/info
+           ;; :kaocha.plugin.alpha/spec-test-check
+           ;; :kaocha.plugin/orchestra
+           ]
+
+ :tests [{:id         :clj
+          :test-paths ["test"]}]
+
+ :reporter kaocha.report/documentation}


### PR DESCRIPTION
Change a few things in the way tests are run:

- use Kaocha to run clojure tests
-  rewrite the circleci configuration to use 3 different jobs
-  add a missing `is` that was discovered when running kaocha

Clojurescript tests should also be ported but it's not so easy unfortunately, so should be done in another PR later on.