### PR TITLE
Using `yyyy` (year-of-era) rather than `YYYY` (week-based-year) in ical formatters

### DIFF
--- a/src/tick/alpha/ical.clj
+++ b/src/tick/alpha/ical.clj
@@ -45,12 +45,12 @@
 (defprotocol ICalendarValue
   (serialize-value [_] ""))
 
-(def DATE-TIME-FORM-1-PATTERN (DateTimeFormatter/ofPattern "YYYYMMdd'T'HHmmss"))
+(def DATE-TIME-FORM-1-PATTERN (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss"))
 
 ;; Only call with ZoneID of UTC otherwise produces invalid ICAL format
-(def DATE-TIME-FORM-2-PATTERN (DateTimeFormatter/ofPattern "YYYYMMdd'T'HHmmssX"))
+(def DATE-TIME-FORM-2-PATTERN (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmssX"))
 
-(def DATE-TIME-FORM-3-PATTERN (DateTimeFormatter/ofPattern "YYYYMMdd'T'HHmmss"))
+(def DATE-TIME-FORM-3-PATTERN (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmss"))
 
 (extend-protocol ICalendarValue
   String


### PR DESCRIPTION
No difference most of the time, but matters in the last week of the year - was rendering `2021-12-31` as `20221231` :)