### PR TITLE
Impl IConversion for LocalDate

### DIFF
--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -221,6 +221,12 @@
   #?(:clj Number :cljs number)
   (instant [n] (cljc.java-time.instant/of-epoch-milli n))
 
+  LocalDate
+  (inst [ld] (p/inst (p/zoned-date-time ld)))
+  (instant [ld] (p/instant (p/zoned-date-time ld)))
+  (offset-date-time [ld] (cljc.java-time.zoned-date-time/to-offset-date-time (p/zoned-date-time ld)))
+  (zoned-date-time [ld] (cljc.java-time.local-date/at-start-of-day ld (current-zone)))
+
   LocalDateTime
   (inst [ldt] (p/inst (p/zoned-date-time ldt)))
   (instant [ldt] (p/instant (p/zoned-date-time ldt)))

--- a/test/tick/api_test.cljc
+++ b/test/tick/api_test.cljc
@@ -110,6 +110,7 @@
 (deftest instant-test
   (testing "instant basics"
     (is (t/instant? (t/instant (t/now))))
+    (is (t/instant? (t/instant (t/date))))
     (is (t/instant? (t/instant (str cljc.java-time.instant/min))))
     (is (t/instant? (t/instant (t/zoned-date-time)))))
 
@@ -117,11 +118,13 @@
     (let [t "2018-09-24T18:57:08.996+01:00"]
       (testing "offset date time basics"
         (is (t/offset-date-time? (t/offset-date-time (t/now))))
+        (is (t/offset-date-time? (t/offset-date-time (t/date))))
         (is (t/offset-date-time? (t/offset-date-time t)))
         (is (t/offset-date-time? (t/offset-date-time (t/date-time))))
         (is (t/offset-date-time? (t/offset-date-time (t/zoned-date-time))))))))
 
 (deftest zoned-date-time-test
+  (is (t/zoned-date-time? (t/zoned-date-time (t/date "2020-12-15"))))
   (is (t/zoned-date-time? (t/zoned-date-time "2020-12-15T12:00:10Z[Europe/London]")))
   (is (t/zoned-date-time? (t/zoned-date-time "2020-12-15T12:00:10+04:00[Europe/London]"))))
 


### PR DESCRIPTION
Hi, is this alright to add to the API?

Would like to be able to convert `tomorrow` into an instant so I can get the period between now and beginning of tomorrow.

Tests:
```
61 tests, 659 assertions, 0 failures.
#:kaocha.result{:count 61, :pass 659, :error 0, :fail 0, :pending 0}
...
Chrome Headless 98.0.4758.102 (Linux x86_64): Executed 57 of 58 SUCCESS (0.124 secs / 0.104 secs)
TOTAL: 57 SUCCESS
...
Ran 57 tests containing 640 assertions.
0 failures, 0 errors.
```