### PR TITLE
Comparison for duration returns ints instead of bools

### DIFF
--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -1220,7 +1220,7 @@
   (= [x y] (clojure.core/= x y))
   Duration
   (< [x y] (neg? (cljc.java-time.duration/compare-to x y)))
-  (<= [x y] (or (clojure.core/= x y) (cljc.java-time.duration/compare-to x y)))
+  (<= [x y] (or (clojure.core/= x y) (neg? (cljc.java-time.duration/compare-to x y))))
   (> [x y] (pos? (cljc.java-time.duration/compare-to x y)))
   (>= [x y] (or (clojure.core/= x y) (pos? (cljc.java-time.duration/compare-to x y))))
   (= [x y] (clojure.core/= x y)))

--- a/test/tick/api_test.cljc
+++ b/test/tick/api_test.cljc
@@ -311,8 +311,12 @@
   (testing "durations"
     (is (t/> (t/new-duration 20 :seconds) (t/new-duration 10 :seconds)))
     (is (t/>= (t/new-duration 20 :seconds) (t/new-duration 20 :seconds)))
+    (is (t/>= (t/new-duration 20 :seconds) (t/new-duration 19 :seconds)))
+    (is (not (t/>= (t/new-duration 19 :seconds) (t/new-duration 20 :seconds))))
     (is (t/< (t/new-duration 10 :seconds) (t/new-duration 20 :seconds)))
-    (is (t/<= (t/new-duration 20 :seconds) (t/new-duration 20 :seconds)))))
+    (is (t/<= (t/new-duration 20 :seconds) (t/new-duration 20 :seconds)))
+    (is (t/<= (t/new-duration 19 :seconds) (t/new-duration 20 :seconds)))
+    (is (not (t/<= (t/new-duration 20 :seconds) (t/new-duration 19 :seconds))))))
 
 
 (deftest comparison-test-date


### PR DESCRIPTION
A missing call to `neg?` means that `<=` for durations return -1 or 1 (or `true` when the values are equal), i.e., the return value is always truthy.