### PR TITLE
Fix issue with parsing iana tokens with hyphens

### DIFF
--- a/src/tick/alpha/ical.clj
+++ b/src/tick/alpha/ical.clj
@@ -213,7 +213,7 @@
              (set (char-range \0 \9))))
 
 (s/def ::iana-token
-  (s/+ (conj ALPHA-DIGIT #{\-})))
+  (s/+ (conj ALPHA-DIGIT \-)))
 
 (s/def ::x-name
   (s/cat

--- a/test/tick/alpha/ical_test.clj
+++ b/test/tick/alpha/ical_test.clj
@@ -4,7 +4,7 @@
   (:require
    [tick.alpha.ical :as ical]
    [clojure.java.io :as io]
-   [clojure.test :refer [deftest is]]))
+   [clojure.test :refer [deftest is testing]]))
 
 (deftest parse-dtstart
   (let [{:keys [name params value]} (ical/line->contentline "DTSTART;TZID=US-EAST:20180116T140000")]
@@ -27,3 +27,16 @@
 (deftest ^:tick.test/slow parse-icalendar-test
   (let [result (ical/parse-ical (io/reader (io/resource "gb.ics")))]
     (is (= 231 (-> result first :subobjects count)))))
+
+(deftest line->contentline-test
+  (testing "Simple lines can be parsed to contentlines"
+    (is (= {:name "SEQUENCE" :value "1" :params {} :string-value "1"} (ical/line->contentline "SEQUENCE:1")))
+    (is (= {:name "sequence" :value "1" :params {} :string-value "1"} (ical/line->contentline "sequence:1")))
+    (is (= {:name "SeqUence" :value "1" :params {} :string-value "1"} (ical/line->contentline "SeqUence:1")))
+    (is (= {:name "REFRESH-INTERVAL" :value "7" :params {} :string-value "7"} (ical/line->contentline "REFRESH-INTERVAL:7"))))
+
+  (testing "Lines with parameters can be parsed to contentlines"
+    (let [{:keys [name params value]} (ical/line->contentline "DTSTART;TZID=US-EAST:20180116T140000")]
+      (is (= "DTSTART" name))
+      (is (= "US-EAST" (get params "TZID")))
+      (is (= "20180116T140000" value)))))


### PR DESCRIPTION
This issue showed up when parsing `REFRESH-INTERVAL;VALUE=DURATION:PT48H` from ical files.
Previously would fail with `\- - failed: #{\:} in: [7] at: [:colon] spec: :user/contentline`