### PR TITLE
Fix formatting error in reference

### DIFF
--- a/docs/cookbook/reference.adoc
+++ b/docs/cookbook/reference.adoc
@@ -702,8 +702,6 @@ specified offset:
 ====
 
 ====
-
-====
 `pm` - Give an interval covering the afternoon of a given date:
 [source.code,clojure]
 ----


### PR DESCRIPTION
Fixes weird formatting, see img for current behaviour.
![image](https://user-images.githubusercontent.com/8146007/201649981-c3ed6103-b993-4840-addb-c2555902f7b9.png)

