### PR TITLE
Bugfix for twelve-hour-time example fn

### DIFF
--- a/docs/cookbook/time.adoc
+++ b/docs/cookbook/time.adoc
@@ -343,9 +343,12 @@ Give the am pm time:
       (>= hour 12)
       (format "%02d:%02d PM" hour minute)
 
-      (< hour 12)
-      (format "%02d:%02d AM" hour minute))))
+      (>= hour 1)
+      (format "%02d:%02d AM" hour minute)
 
+      (= hour 0)
+      (format "12:%02d AM" minute))))
+      
 ----
 NOTE: "12 noon is by definition neither *ante meridiem* (before noon) nor *post
 meridiem* (after noon), then 12 a.m. refers to midnight at the start of the


### PR DESCRIPTION
For times between midnight and 1:00 AM, e.g. 12:15 AM, the twelve-hour-time fn was previously returning 00:15 AM. Now it correctly returns 12:15 AM.