### PR TITLE
Make interval/concur handle three or more adjecent intervals

### DIFF
--- a/src/tick/alpha/interval.cljc
+++ b/src/tick/alpha/interval.cljc
@@ -327,12 +327,14 @@
   representing the interval of time the given intervals are
   concurrent."
   ([x y]
-   (case (relation x y)
-     :overlaps (slice x (t/beginning y) (t/end x))
-     :overlapped-by (slice x (t/beginning x) (t/end y))
-     (:starts :finishes :during :equals) x
-     (:started-by :finished-by :contains) (slice x (t/beginning y) (t/end y))
-     nil))
+   (if (or (nil? x) (nil? y))
+     nil
+     (case (relation x y)
+       :overlaps (slice x (t/beginning y) (t/end x))
+       :overlapped-by (slice x (t/beginning x) (t/end y))
+       (:starts :finishes :during :equals) x
+       (:started-by :finished-by :contains) (slice x (t/beginning y) (t/end y))
+       nil)))
   ([x y & args]
    (reduce concur (concur x y) args)))
 

--- a/test/tick/alpha/interval_test.cljc
+++ b/test/tick/alpha/interval_test.cljc
@@ -164,7 +164,29 @@
       (ti/new-interval (instants 1) (instants 3))
       (ti/concur
         (ti/new-interval (instants 1) (instants 3))
-        (ti/new-interval (instants 0) (instants 3))))))
+        (ti/new-interval (instants 0) (instants 3)))))
+
+  (is
+    (=
+      (ti/new-interval (instants 1) (instants 2))
+      (ti/concur
+        (ti/new-interval (instants 1) (instants 3))
+        (ti/new-interval (instants 1) (instants 2))
+        (ti/new-interval (instants 0) (instants 2)))))
+
+  (is
+    (nil?
+      (ti/concur
+        (ti/new-interval (instants 1) (instants 2))
+        (ti/new-interval (instants 2) (instants 3))
+        (ti/new-interval (instants 0) (instants 2)))))
+
+  (is
+    (nil?
+      (ti/concur
+        (ti/new-interval (instants 0) (instants 1))
+        (ti/new-interval (instants 1) (instants 2))
+        (ti/new-interval (instants 2) (instants 3))))))
 
 ;; Sequence tests
 


### PR DESCRIPTION
The tests for interval/concur had no case with three or more arguments. Therefore the case where two adjecent intervals returns nil that is sent to (relation x y) in the next iteration was missed.
