### PR TITLE
ical.clj. Fix multiline folding according to rfc2445

### DIFF
--- a/src/tick/alpha/ical.clj
+++ b/src/tick/alpha/ical.clj
@@ -263,7 +263,7 @@
   [^java.io.BufferedReader rdr hold]
   (if-let [line (.readLine rdr)]
     (if (= (.charAt line 0) \space)
-      (recur rdr (conj hold line))
+      (recur rdr (conj hold (.substring line 1)))
       (cons (str/join hold) (lazy-seq (unfolding-line-seq* rdr [line]))))
     [(str/join hold)]))
 

--- a/src/tick/alpha/ical.clj
+++ b/src/tick/alpha/ical.clj
@@ -262,9 +262,10 @@
 (defn unfolding-line-seq*
   [^java.io.BufferedReader rdr hold]
   (if-let [line (.readLine rdr)]
-    (if (= (.charAt line 0) \space)
-      (recur rdr (conj hold (.substring line 1)))
-      (cons (str/join hold) (lazy-seq (unfolding-line-seq* rdr [line]))))
+    (cond
+      (.isEmpty line) (recur rdr hold)
+      (= (.charAt line 0) \space) (recur rdr (conj hold (.substring line 1)))
+      :else (cons (str/join hold) (lazy-seq (unfolding-line-seq* rdr [line]))))
     [(str/join hold)]))
 
 (defn unfolding-line-seq [^java.io.BufferedReader rdr]

--- a/test/tick/alpha/ical_test.clj
+++ b/test/tick/alpha/ical_test.clj
@@ -60,3 +60,18 @@
                ical/unfolding-line-seq
                first
                ical/line->contentline)))))
+
+(def multi-with-empty
+  "X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-SOME-HEADER-BREAKING-SOMEWHERE-AT-
+ 75=foobar;X-TITLE=Some Place:geo:44.815458,20.462758
+
+FOO:bar")
+
+(deftest parse-line-ignore-empty-test
+  (testing "Empty lines are ignored"
+    (is (= ["X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-SOME-HEADER-BREAKING-SOMEWHERE-AT-75=foobar;X-TITLE=Some Place:geo:44.815458,20.462758"
+            "FOO:bar"]
+           (-> multi-with-empty
+               char-array
+               io/reader
+               ical/unfolding-line-seq)))))

--- a/test/tick/alpha/ical_test.clj
+++ b/test/tick/alpha/ical_test.clj
@@ -40,3 +40,23 @@
       (is (= "DTSTART" name))
       (is (= "US-EAST" (get params "TZID")))
       (is (= "20180116T140000" value)))))
+
+(def multiline
+  "X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-SOME-HEADER-BREAKING-SOMEWHERE-AT-
+ 75=foobar;X-TITLE=Some Place:geo:44.815458,20.462758")
+
+(deftest parse-line-folding-test
+  (testing "Folded lines can be parsed"
+    (is (= {:name "X-APPLE-STRUCTURED-LOCATION",
+            :params
+            {"VALUE" "URI",
+             "X-SOME-HEADER-BREAKING-SOMEWHERE-AT-75" "foobar",
+             "X-TITLE" "Some Place"},
+            :value "geo:44.815458,20.462758",
+            :string-value "geo:44.815458,20.462758"}
+           (-> multiline
+               char-array
+               io/reader
+               ical/unfolding-line-seq
+               first
+               ical/line->contentline)))))


### PR DESCRIPTION
Hi, I'm trying to parse an ics file that contains long lines split by so called "line folding technique".

According to https://www.ietf.org/rfc/rfc2445.txt

    Lines of text SHOULD NOT be longer than 75 octets, excluding the line
    break. Long content lines SHOULD be split into a multiple line
    representations using a line "folding" technique. That is, a long
    line can be split between any two characters by inserting a CRLF
    immediately followed by a single linear white space character (i.e.,
    SPACE, US-ASCII decimal 32 or HTAB, US-ASCII decimal 9). Any sequence
    of CRLF followed immediately by a single linear white space character
    is ignored (i.e., removed) when processing the content type.

Unfortunately, while `unfolding-line-seq*`concatenates such lines properly, it doesn't skip the leading whitespace character, This can cause the parser to break.

To reproduce (see ical_test.clj):

```clojure
(require '[tick.alpha.ical :as ical])

(def multiline
  "X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-SOME-HEADER-BREAKING-SOMEWHERE-AT-
  75=foobar;X-TITLE=Some Place:geo:44.815458,20.462758")

(deftest parse-line-folding-test
  (testing "Folded lines can be parsed"
    (is (= {:name "X-APPLE-STRUCTURED-LOCATION",
            :params
            {"VALUE" "URI",
             "X-SOME-HEADER-BREAKING-SOMEWHERE-AT-75" "foobar",
             "X-TITLE" "Some Place"},
            :value "geo:44.815458,20.462758",
            :string-value "geo:44.815458,20.462758"}
           (-> multiline
               char-array
               io/reader
               ical/unfolding-line-seq
               first
               ical/line->contentline)))))
```
By default results in:

```
1. Caused by clojure.lang.ExceptionInfo
   No name
   {:contentline
    "X-APPLE-STRUCTURED-LOCATION;VALUE=URI;X-SOME-HEADER-BREAKING-SOMEWHERE-AT- 75=foobar;X-TITLE=Some Place:geo:44.815458,20.462758"}
                  ical.clj:  286  tick.alpha.ical/line->contentline
                  ical.clj:  284  tick.alpha.ical/line->contentline

```

The fix skips the initial space char while concatenating.