### PR TITLE
Fix tick.core/micros for negative durations (#208)

### DIFF
--- a/src/tick/core.cljc
+++ b/src/tick/core.cljc
@@ -628,7 +628,7 @@
 (extend-protocol p/ITimeLength
   Duration
   (nanos [d] (cljc.java-time.duration/to-nanos d))
-  (micros [d] (#?(:clj Long/divideUnsigned :cljs cljs.core//) (p/nanos d) 1000))
+  (micros [d] (quot (p/nanos d) 1000))
   (millis [d] (cljc.java-time.duration/to-millis d))
   (seconds [d] (cljc.java-time.duration/get-seconds d))
   (minutes [d] (cljc.java-time.duration/to-minutes d))

--- a/test/tick/api_test.cljc
+++ b/test/tick/api_test.cljc
@@ -445,7 +445,39 @@
   (is (= (t/of-millis 10) (t/new-duration 10 :millis)))
   (is (= (t/of-seconds 10) (t/new-duration 10 :seconds)))
   (is (= (t/of-minutes 10) (t/new-duration 10 :minutes)))
-  (is (= (t/of-hours 10) (t/new-duration 10 :hours))))
+  (is (= (t/of-hours 10) (t/new-duration 10 :hours)))
+
+  (testing "negative durations"
+    ;; #208: micros previously returned large positive values via Long/divideUnsigned
+    (is (= -1000000000 (t/nanos  (t/of-seconds -1))))
+    (is (= -1000000    (t/micros (t/of-seconds -1))))
+    (is (= -1000       (t/millis (t/of-seconds -1))))
+    (is (= -1 (t/seconds (t/of-seconds -1))))
+    (is (= -1 (t/minutes (t/of-minutes -1))))
+    (is (= -1 (t/hours   (t/of-hours   -1))))
+    (is (= -1 (t/days    (t/of-days    -1)))))
+
+  (testing "truncation"
+    ;; All unit fns truncate toward zero for positive durations
+    (is (= 1 (t/micros  (t/of-nanos  1001))))
+    (is (= 1 (t/millis  (t/of-micros 1234))))
+    (is (= 1 (t/seconds (t/of-millis 1999))))
+    (is (= 1 (t/minutes (t/of-seconds 61))))
+    (is (= 1 (t/hours   (t/of-minutes 99))))
+    (is (= 1 (t/days    (t/of-hours   25))))
+
+    ;; Negative seconds truncate toward -Infinity (due to internal repr)
+    (is (= -2 (t/seconds (t/of-nanos  -1000000001))))
+    (is (= -2 (t/seconds (t/of-micros -1000001))))
+    (is (= -2 (t/seconds (t/of-millis -1001))))
+
+    ;; All other negative units truncate toward zero
+    (is (= -1 (t/micros  (t/of-nanos  -1234))))
+    (is (= -1 (t/millis  (t/of-nanos  -1999999))))
+    (is (= -1 (t/millis  (t/of-micros -1001))))
+    (is (= -1 (t/minutes (t/of-seconds -61))))
+    (is (= -1 (t/hours   (t/of-minutes -99))))
+    (is (= -1 (t/days    (t/of-hours   -25))))))
 
 
 ;; Periods. Convenience functions to create periods of specific

--- a/test/tick/api_test.cljc
+++ b/test/tick/api_test.cljc
@@ -472,10 +472,12 @@
     (is (= -2 (t/seconds (t/of-micros -1000001))))
     (is (= -2 (t/seconds (t/of-millis -1001))))
 
+    ;; Behavior of millis is platform-dependent (discrepancy in underlying js-joda lib vs java-time)
+    (is (= #?(:clj -1 :cljs -2) (t/millis (t/of-nanos  -1999999))))
+    (is (= #?(:clj -1 :cljs -2) (t/millis (t/of-micros -1001))))
+
     ;; All other negative units truncate toward zero
     (is (= -1 (t/micros  (t/of-nanos  -1234))))
-    (is (= -1 (t/millis  (t/of-nanos  -1999999))))
-    (is (= -1 (t/millis  (t/of-micros -1001))))
     (is (= -1 (t/minutes (t/of-seconds -61))))
     (is (= -1 (t/hours   (t/of-minutes -99))))
     (is (= -1 (t/days    (t/of-hours   -25))))))

--- a/test/tick/api_test.cljc
+++ b/test/tick/api_test.cljc
@@ -34,9 +34,10 @@
     (is (= "12:00" (str (t/noon))))))
 
 (deftest date-construction-test
-  (is (= (t/date "2018-01-11")
-        (t/date (t/instant 1515691416624))))
-  (is (t/date-time? (t/noon (t/today))))
+  (t/with-clock (t/zone-offset 0)
+    (is (= (t/date "2018-01-11")
+           (t/date (t/instant 1515691416624))))
+    (is (t/date-time? (t/noon (t/today)))))
   (t/with-clock (-> (t/date "2018-02-14") (t/at "10:00"))
     (testing "(noon (today))"
       (is (= "2018-02-14T12:00" (str (t/noon (t/today))))))


### PR DESCRIPTION
Closes #208. 

(Side note: I had an unrelated test failure here https://github.com/juxt/tick/blob/bd2eefdb5414572f1aeabb345d2d62a107662297/test/tick/api_test.cljc#L37-L38 
which seems to be a faullty test? The t/date conversion depends on ambient clock / timezone, which in my case happened to return #time/date "2018-01-12")